### PR TITLE
feat: Support loading git SSH keys from dg.EnvVar

### DIFF
--- a/src/dagster_meltano_pipelines/components/meltano_pipeline/component.py
+++ b/src/dagster_meltano_pipelines/components/meltano_pipeline/component.py
@@ -66,7 +66,7 @@ ResolvedMeltanoProject: TypeAlias = t.Annotated[
 @contextmanager
 def setup_ssh_config(
     context: dg.AssetExecutionContext,
-    ssh_private_keys: t.List[str],
+    ssh_private_keys: t.Sequence[t.Union[str, dg.EnvVar]],
 ) -> t.Generator[t.Optional[str], None, None]:
     """Create temporary SSH config and key files for Git authentication.
 
@@ -87,6 +87,13 @@ def setup_ssh_config(
 
             # Create and enter context for each key file
             for i, key_content in enumerate(ssh_private_keys):
+                # Resolve EnvVar if needed
+                if isinstance(key_content, dg.EnvVar):
+                    resolved_key = key_content.get_value()
+                    if resolved_key is None:
+                        raise ValueError(f"Environment variable for SSH key at index {i} is not set")
+                    key_content = resolved_key
+
                 # Replace literal \n with actual newlines
                 key_content = key_content.replace("\\n", "\n")
                 if not key_content.endswith("\n"):

--- a/tests/test_ssh_config.py
+++ b/tests/test_ssh_config.py
@@ -41,6 +41,48 @@ key2content
     ]
 
 
+@pytest.fixture
+def env_ssh_key_content() -> str:
+    """SSH key content for environment variable testing."""
+    return """-----BEGIN OPENSSH PRIVATE KEY-----
+test-key-from-env-var
+-----END OPENSSH PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def string_ssh_key() -> str:
+    """SSH key for mixed type testing."""
+    return """-----BEGIN OPENSSH PRIVATE KEY-----
+string-key-content
+-----END OPENSSH PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def env_ssh_key_content_mixed() -> str:
+    """SSH key content for mixed type environment variable testing."""
+    return """-----BEGIN OPENSSH PRIVATE KEY-----
+env-key-content
+-----END OPENSSH PRIVATE KEY-----"""
+
+
+@pytest.fixture
+def ssh_key_with_literal_newlines() -> str:
+    """SSH key with literal \\n characters for newline replacement testing."""
+    return "-----BEGIN OPENSSH PRIVATE KEY-----\\nb3BlbnNzaC1rZXktdjE=\\n-----END OPENSSH PRIVATE KEY-----"
+
+
+@pytest.fixture
+def expected_ssh_key_with_real_newlines() -> str:
+    """Expected SSH key content after literal newline replacement."""
+    return "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE=\n-----END OPENSSH PRIVATE KEY-----\n"
+
+
+@pytest.fixture
+def secret_key_content() -> str:
+    """Simple secret key content for testing."""
+    return "test-secret-key-content"
+
+
 def test_setup_ssh_config_empty_keys(mock_context: Mock) -> None:
     """Test that setup_ssh_config yields None when no SSH keys are provided."""
     with setup_ssh_config(mock_context, []) as ssh_config_path:
@@ -163,10 +205,9 @@ def test_setup_ssh_config_temp_directory_isolation(mock_context: Mock, sample_ss
         assert not os.path.exists(temp_dir)
 
 
-def test_setup_ssh_config_secret_str_handling(mock_context: Mock) -> None:
+def test_setup_ssh_config_secret_str_handling(mock_context: Mock, secret_key_content: str) -> None:
     """Test that SecretStr values are properly handled."""
-    secret_key = "test-secret-key-content"
-    ssh_keys = [secret_key]
+    ssh_keys = [secret_key_content]
 
     with setup_ssh_config(mock_context, ssh_keys) as ssh_config_path:
         assert ssh_config_path is not None
@@ -177,7 +218,7 @@ def test_setup_ssh_config_secret_str_handling(mock_context: Mock) -> None:
         # Verify the secret value was written to the file (should have trailing newline added)
         with open(key_file_path, "r") as f:
             key_content = f.read()
-        assert key_content == "test-secret-key-content\n"
+        assert key_content == secret_key_content + "\n"
 
 
 def test_setup_ssh_config_file_naming(mock_context: Mock, sample_ssh_keys: t.List[str]) -> None:
@@ -210,17 +251,11 @@ def test_setup_ssh_config_file_naming(mock_context: Mock, sample_ssh_keys: t.Lis
             assert key_file_path in config_content
 
 
-def test_setup_ssh_config_literal_newline_replacement(mock_context: Mock) -> None:
+def test_setup_ssh_config_literal_newline_replacement(
+    mock_context: Mock, ssh_key_with_literal_newlines: str, expected_ssh_key_with_real_newlines: str
+) -> None:
     """Test that literal \\n strings are replaced with actual newlines in SSH keys."""
-    # SSH key with literal \n characters instead of actual newlines
-    ssh_key_with_literals = (
-        "-----BEGIN OPENSSH PRIVATE KEY-----\\nb3BlbnNzaC1rZXktdjE=\\n-----END OPENSSH PRIVATE KEY-----"
-    )
-    expected_key_content = (
-        "-----BEGIN OPENSSH PRIVATE KEY-----\nb3BlbnNzaC1rZXktdjE=\n-----END OPENSSH PRIVATE KEY-----\n"
-    )
-
-    ssh_keys = [ssh_key_with_literals]
+    ssh_keys = [ssh_key_with_literal_newlines]
 
     with setup_ssh_config(mock_context, ssh_keys) as ssh_config_path:
         assert ssh_config_path is not None
@@ -234,8 +269,84 @@ def test_setup_ssh_config_literal_newline_replacement(mock_context: Mock) -> Non
         # Verify the literal \n was replaced with actual newlines
         with open(key_file_path, "r") as f:
             key_content = f.read()
-        assert key_content == expected_key_content
+        assert key_content == expected_ssh_key_with_real_newlines
 
         # Verify it contains actual newlines, not literal \n
         assert "\\n" not in key_content
         assert "\n" in key_content
+
+
+def test_setup_ssh_config_env_var_not_set(mock_context: Mock) -> None:
+    """Test SSH config setup with unset EnvVar raises appropriate error."""
+    # Create SSH keys list with unset EnvVar
+    ssh_keys = [dg.EnvVar("UNSET_SSH_KEY")]
+
+    with pytest.raises(ValueError, match=r"Environment variable for SSH key at index 0 is not set"):
+        with setup_ssh_config(mock_context, ssh_keys):
+            pass
+
+
+def test_setup_ssh_config_with_env_var(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, env_ssh_key_content: str
+) -> None:
+    """Test SSH config setup with dg.EnvVar values."""
+    # Set up environment variable
+    monkeypatch.setenv("SSH_PRIVATE_KEY", env_ssh_key_content)
+
+    # Create SSH keys list with EnvVar
+    ssh_keys = [dg.EnvVar("SSH_PRIVATE_KEY")]
+
+    with setup_ssh_config(mock_context, ssh_keys) as ssh_config_path:
+        assert ssh_config_path is not None
+        assert os.path.exists(ssh_config_path)
+
+        # Read and verify SSH config content
+        with open(ssh_config_path, "r") as f:
+            config_content = f.read()
+
+        assert "Host *" in config_content
+        assert "IdentityFile" in config_content
+        assert "IdentitiesOnly yes" in config_content
+
+        # Find the key file referenced in the config
+        temp_dir = os.path.dirname(ssh_config_path)
+        key_files = [f for f in os.listdir(temp_dir) if f.endswith("_id_rsa_0")]
+        assert len(key_files) == 1
+        key_file_path = os.path.join(temp_dir, key_files[0])
+
+        # Verify key file content (should have trailing newline added)
+        with open(key_file_path, "r") as f:
+            key_content = f.read()
+        expected_content = env_ssh_key_content + "\n"
+        assert key_content == expected_content
+
+
+def test_setup_ssh_config_mixed_types(
+    mock_context: Mock, monkeypatch: pytest.MonkeyPatch, string_ssh_key: str, env_ssh_key_content_mixed: str
+) -> None:
+    """Test SSH config setup with mixed string and EnvVar values."""
+    # Set up environment variable
+    monkeypatch.setenv("SSH_ENV_KEY", env_ssh_key_content_mixed)
+
+    # Create SSH keys list with mixed types
+    ssh_keys = [string_ssh_key, dg.EnvVar("SSH_ENV_KEY")]
+
+    with setup_ssh_config(mock_context, ssh_keys) as ssh_config_path:
+        assert ssh_config_path is not None
+        assert os.path.exists(ssh_config_path)
+
+        # Verify temp directory has correct number of key files
+        temp_dir = os.path.dirname(ssh_config_path)
+        key_files = [f for f in os.listdir(temp_dir) if "_id_rsa_" in f]
+        assert len(key_files) == 2
+
+        # Verify each key file has correct content
+        for i, expected_key in enumerate([string_ssh_key, env_ssh_key_content_mixed]):
+            key_file = [f for f in key_files if f.endswith(f"_id_rsa_{i}")][0]
+            key_file_path = os.path.join(temp_dir, key_file)
+
+            # Check content (should have trailing newline added if missing)
+            with open(key_file_path, "r") as f:
+                key_content = f.read()
+            expected_content = expected_key if expected_key.endswith("\n") else expected_key + "\n"
+            assert key_content == expected_content


### PR DESCRIPTION
## Summary
- Added support for `dg.EnvVar` in `git_ssh_private_keys` field of `MeltanoPipeline`
- Maintains backward compatibility with existing string-based SSH keys
- Supports mixed lists of strings and `dg.EnvVar` values

## Changes
- Updated `MeltanoPipeline.git_ssh_private_keys` type from `List[str]` to `List[Union[str, dg.EnvVar]]`
- Changed `MeltanoPipeline` and `DagsterAssetProps` base class from `BaseModel` to `dg.PermissiveConfig` to handle `dg.EnvVar` types
- Modified `setup_ssh_config()` to resolve `dg.EnvVar` values before processing SSH keys
- Added proper error handling for unset environment variables
- Updated type hints to use `Sequence` for better variance compatibility

## Test plan
- [x] All existing SSH config tests pass
- [x] New tests for `dg.EnvVar` functionality:
  - `test_setup_ssh_config_with_env_var`: Tests EnvVar with set environment variables
  - `test_setup_ssh_config_mixed_types`: Tests mixing string and EnvVar values
  - `test_setup_ssh_config_env_var_not_set`: Tests error handling for unset environment variables
- [x] Refactored tests to use reusable fixtures for better maintainability
- [x] Type checking passes with strict mypy
- [x] Linting passes with ruff

🤖 Generated with [Claude Code](https://claude.ai/code)