### PR TITLE
feat: Move git SSH key configuration to per-plugin level

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,28 @@ pipelines:
   my_pipeline:
     extractor:
       name: tap-csv
+      git_ssh_private_key: "{{ env_var('EXTRACTOR_SSH_KEY') }}"  # SSH key for extractor Git authentication
     loader:
       name: target-jsonl
+      git_ssh_private_key: "{{ env_var('LOADER_SSH_KEY') }}"  # SSH key for loader Git authentication
     description: "Extract data from CSV and load to JSONL"
     tags:
       environment: "dev"
 ```
+
+#### Git SSH Authentication
+
+For Git repositories that require SSH authentication, you can configure an SSH private key on individual plugins (extractors and loaders):
+
+```yaml
+pipelines:
+  my_pipeline:
+    extractor:
+      name: tap-github
+      git_ssh_private_key: "{{ env_var('GITHUB_SSH_KEY') }}"
+    loader:
+      name: target-postgres
+      # No SSH key needed for this loader
+```
+
+**Note:** Pipeline-level `git_ssh_private_keys` configuration is deprecated. Configure `git_ssh_private_key` on individual extractor and loader plugins instead.

--- a/src/dagster_meltano_pipelines/components/meltano_pipeline/component.py
+++ b/src/dagster_meltano_pipelines/components/meltano_pipeline/component.py
@@ -64,6 +64,38 @@ ResolvedMeltanoProject: TypeAlias = t.Annotated[
 ]
 
 
+def get_all_ssh_keys(pipeline: "MeltanoPipeline") -> t.List[str]:
+    """Collect SSH keys from all sources with deprecation warning.
+
+    Args:
+        pipeline: The Meltano pipeline configuration
+
+    Returns:
+        List of SSH private key contents
+    """
+    ssh_keys = []
+
+    # Collect keys from plugins (new approach)
+    if pipeline.extractor.git_ssh_private_key:
+        ssh_keys.append(pipeline.extractor.git_ssh_private_key)
+    if pipeline.loader.git_ssh_private_key:
+        ssh_keys.append(pipeline.loader.git_ssh_private_key)
+
+    # Handle deprecated pipeline-level keys
+    if pipeline.git_ssh_private_keys:
+        import warnings
+
+        warnings.warn(
+            "Pipeline-level git_ssh_private_keys is deprecated. "
+            "Configure git_ssh_private_key on individual extractor and loader plugins instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
+        ssh_keys.extend(pipeline.git_ssh_private_keys)
+
+    return ssh_keys
+
+
 @contextmanager
 def setup_ssh_config(
     context: dg.AssetExecutionContext,
@@ -283,7 +315,7 @@ def pipeline_to_dagster_asset(
                 project.project_dir,
             )
 
-        with setup_ssh_config(context, pipeline.git_ssh_private_keys) as ssh_config_path:
+        with setup_ssh_config(context, get_all_ssh_keys(pipeline)) as ssh_config_path:
             env = build_pipeline_env(pipeline, project, ssh_config_path, flags=config)
             _run_meltano_pipeline(context, pipeline, project, env, flags=config)
 
@@ -360,7 +392,8 @@ class MeltanoPipeline(BaseModel):
     )
     git_ssh_private_keys: t.List[str] = Field(
         default_factory=list,
-        description="List of SSH private key contents for Git authentication",
+        description="(DEPRECATED) List of SSH private key contents for Git authentication. "
+        "Use git_ssh_private_key on individual extractor and loader plugins instead.",
     )
 
     state_suffix: t.Optional[str] = Field(None, description="Suffix to add to the state backend environment variables")

--- a/src/dagster_meltano_pipelines/resources.py
+++ b/src/dagster_meltano_pipelines/resources.py
@@ -68,6 +68,10 @@ class MeltanoPlugin(dg.ConfigurableResource["MeltanoPlugin"]):
 
     name: str = Field(description="The Meltano plugin name")
     config: Optional[MeltanoPluginConfig] = Field(description="The Meltano plugin configuration")
+    git_ssh_private_key: Optional[str] = Field(
+        default=None,
+        description="SSH private key content for Git authentication",
+    )
 
     def as_env(self) -> Dict[str, str]:
         """Convert the plugin configuration to a dictionary of environment variables."""

--- a/tests/test_pipeline_env.py
+++ b/tests/test_pipeline_env.py
@@ -36,6 +36,7 @@ def simple_extractor() -> Extractor:
             api_key="secret123",
             base_url="https://api.test.com",
         ),
+        git_ssh_private_key=None,
     )
 
 
@@ -49,6 +50,7 @@ def simple_loader() -> Loader:
             port=5432,
             database="testdb",
         ),
+        git_ssh_private_key=None,
     )
 
 

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -42,6 +42,7 @@ def extractor() -> Extractor:
             _catalog="catalog.json",
             _select=["foo.*", "baz.*"],
         ),
+        git_ssh_private_key="test-ssh-key",
     )
 
 

--- a/tests/test_ssh_key_collection.py
+++ b/tests/test_ssh_key_collection.py
@@ -1,0 +1,224 @@
+import warnings
+
+import pytest
+
+from dagster_meltano_pipelines.components.meltano_pipeline.component import (
+    MeltanoPipeline,
+    get_all_ssh_keys,
+)
+from dagster_meltano_pipelines.resources import (
+    Extractor,
+    ExtractorConfig,
+    Loader,
+    LoaderConfig,
+)
+
+
+@pytest.fixture
+def extractor_with_ssh() -> Extractor:
+    """Create an extractor with SSH key for testing."""
+    return Extractor(
+        name="tap-github",
+        config=ExtractorConfig(),  # type: ignore[call-arg]
+        git_ssh_private_key="extractor-ssh-key",
+    )
+
+
+@pytest.fixture
+def loader_with_ssh() -> Loader:
+    """Create a loader with SSH key for testing."""
+    return Loader(
+        name="target-postgres",
+        config=LoaderConfig(),  # type: ignore[call-arg]
+        git_ssh_private_key="loader-ssh-key",
+    )
+
+
+@pytest.fixture
+def extractor_no_ssh() -> Extractor:
+    """Create an extractor without SSH key for testing."""
+    return Extractor(
+        name="tap-csv",
+        config=ExtractorConfig(),  # type: ignore[call-arg]
+        git_ssh_private_key=None,
+    )
+
+
+@pytest.fixture
+def loader_no_ssh() -> Loader:
+    """Create a loader without SSH key for testing."""
+    return Loader(
+        name="target-jsonl",
+        config=LoaderConfig(),  # type: ignore[call-arg]
+        git_ssh_private_key=None,
+    )
+
+
+def test_get_all_ssh_keys_from_plugins_only(extractor_with_ssh: Extractor, loader_with_ssh: Loader) -> None:
+    """Test collecting SSH keys from plugins only (no deprecated pipeline keys)."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_with_ssh,
+        loader=loader_with_ssh,
+        git_ssh_private_keys=[],  # No deprecated keys
+    )
+
+    ssh_keys = get_all_ssh_keys(pipeline)
+
+    # Should collect keys from both extractor and loader
+    assert ssh_keys == ["extractor-ssh-key", "loader-ssh-key"]
+
+
+def test_get_all_ssh_keys_mixed_plugins(extractor_with_ssh: Extractor, loader_no_ssh: Loader) -> None:
+    """Test collecting SSH keys when only some plugins have keys."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_with_ssh,
+        loader=loader_no_ssh,
+        git_ssh_private_keys=[],
+    )
+
+    ssh_keys = get_all_ssh_keys(pipeline)
+
+    # Should only collect keys from extractor
+    assert ssh_keys == ["extractor-ssh-key"]
+
+
+def test_get_all_ssh_keys_loader_only(extractor_no_ssh: Extractor, loader_with_ssh: Loader) -> None:
+    """Test collecting SSH keys when only loader has a key."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_no_ssh,
+        loader=loader_with_ssh,
+        git_ssh_private_keys=[],
+    )
+
+    ssh_keys = get_all_ssh_keys(pipeline)
+
+    # Should only collect keys from loader
+    assert ssh_keys == ["loader-ssh-key"]
+
+
+def test_get_all_ssh_keys_no_plugins_have_keys(extractor_no_ssh: Extractor, loader_no_ssh: Loader) -> None:
+    """Test collecting SSH keys when no plugins have keys."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_no_ssh,
+        loader=loader_no_ssh,
+        git_ssh_private_keys=[],
+    )
+
+    ssh_keys = get_all_ssh_keys(pipeline)
+
+    # Should return empty list
+    assert ssh_keys == []
+
+
+def test_get_all_ssh_keys_deprecated_pipeline_keys_only(extractor_no_ssh: Extractor, loader_no_ssh: Loader) -> None:
+    """Test collecting SSH keys from deprecated pipeline-level configuration."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_no_ssh,
+        loader=loader_no_ssh,
+        git_ssh_private_keys=["deprecated-key-1", "deprecated-key-2"],
+    )
+
+    # Test that deprecation warning is raised
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ssh_keys = get_all_ssh_keys(pipeline)
+
+        # Should have raised a deprecation warning
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+        assert "deprecated" in str(w[0].message).lower()
+        assert "git_ssh_private_keys" in str(w[0].message)
+
+    # Should return the deprecated keys
+    assert ssh_keys == ["deprecated-key-1", "deprecated-key-2"]
+
+
+def test_get_all_ssh_keys_mixed_new_and_deprecated(extractor_with_ssh: Extractor, loader_with_ssh: Loader) -> None:
+    """Test collecting SSH keys from both new plugin-level and deprecated pipeline-level configuration."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_with_ssh,
+        loader=loader_with_ssh,
+        git_ssh_private_keys=["deprecated-key-1"],
+    )
+
+    # Test that deprecation warning is raised
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ssh_keys = get_all_ssh_keys(pipeline)
+
+        # Should have raised a deprecation warning
+        assert len(w) == 1
+        assert issubclass(w[0].category, DeprecationWarning)
+
+    # Should collect keys from plugins first, then deprecated keys
+    assert ssh_keys == ["extractor-ssh-key", "loader-ssh-key", "deprecated-key-1"]
+
+
+def test_get_all_ssh_keys_deprecation_warning_message(extractor_no_ssh: Extractor, loader_no_ssh: Loader) -> None:
+    """Test that the deprecation warning has the correct message."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_no_ssh,
+        loader=loader_no_ssh,
+        git_ssh_private_keys=["deprecated-key"],
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        get_all_ssh_keys(pipeline)
+
+        # Check the warning message
+        assert len(w) == 1
+        warning_message = str(w[0].message)
+        assert "Pipeline-level git_ssh_private_keys is deprecated" in warning_message
+        assert "Configure git_ssh_private_key on individual extractor and loader plugins instead" in warning_message
+
+
+def test_get_all_ssh_keys_no_warning_when_no_deprecated_keys(
+    extractor_with_ssh: Extractor, loader_with_ssh: Loader
+) -> None:
+    """Test that no deprecation warning is raised when only using new plugin-level configuration."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_with_ssh,
+        loader=loader_with_ssh,
+        git_ssh_private_keys=[],  # No deprecated keys
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ssh_keys = get_all_ssh_keys(pipeline)
+
+        # Should not raise any warnings
+        assert len(w) == 0
+
+    # Should collect keys from plugins
+    assert ssh_keys == ["extractor-ssh-key", "loader-ssh-key"]
+
+
+def test_get_all_ssh_keys_empty_deprecated_list_no_warning(
+    extractor_with_ssh: Extractor, loader_with_ssh: Loader
+) -> None:
+    """Test that no deprecation warning is raised when deprecated list is empty."""
+    pipeline = MeltanoPipeline(
+        id="test-pipeline",
+        extractor=extractor_with_ssh,
+        loader=loader_with_ssh,
+        git_ssh_private_keys=[],  # Empty deprecated list
+    )
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        ssh_keys = get_all_ssh_keys(pipeline)
+
+        # Should not raise any warnings
+        assert len(w) == 0
+
+    # Should collect keys from plugins
+    assert ssh_keys == ["extractor-ssh-key", "loader-ssh-key"]


### PR DESCRIPTION
## Summary
- Move git SSH key configuration from pipeline level to per-plugin level
- Each plugin (extractor/loader) now has an optional `git_ssh_private_key` field instead of a list
- Maintain backwards compatibility with deprecated pipeline-level `git_ssh_private_keys`
- Add deprecation warning when using pipeline-level configuration

## Changes Made
- **Added** `git_ssh_private_key: Optional[str]` field to `MeltanoPlugin` base class
- **Updated** `get_all_ssh_keys()` function to collect SSH keys from plugins
- **Deprecated** pipeline-level `git_ssh_private_keys` with warning message
- **Updated** documentation in README.md to show new per-plugin configuration
- **Added** comprehensive tests for SSH key collection functionality

## Migration Guide
### Before (deprecated):
```yaml
pipelines:
  my_pipeline:
    git_ssh_private_keys:
      - "{{ env_var('SSH_KEY') }}"
```

### After (recommended):
```yaml
pipelines:
  my_pipeline:
    extractor:
      name: tap-github
      git_ssh_private_key: "{{ env_var('EXTRACTOR_SSH_KEY') }}"
    loader:
      name: target-postgres
      git_ssh_private_key: "{{ env_var('LOADER_SSH_KEY') }}"
```

## Test plan
- [x] All existing tests pass
- [x] New tests for SSH key collection functionality
- [x] Tests for deprecation warning behavior
- [x] Tests for backwards compatibility

🤖 Generated with [Claude Code](https://claude.ai/code)